### PR TITLE
merge hash options to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Policefile.rb or directly using attributes. All GRUB specific settings
 should use underscores like the examples below.
 
 ### Hash merging
-Values provided as hashes (under ['grub']['config']['settings'][key] will be merged/flattened to form strings.
+Values provided as hashes (under `['grub']['config']['settings'][key]`)
+will be merged/flattened to form strings.
 This is intended to allow overrides to, for example, kernel boot options without ugly string manipulation.
 
 This approach is probably best demonstrated using an example:
@@ -51,7 +52,7 @@ for each key = value pair in the hash:
   * if value is `nil`, it is omitted and the key is inserted without a value
     `...[cmdline_linux']['nomodeset'] = nil` results in `nomodeset`
 
-  * if value is an array, the result is key=v1 key=v2... once for each value in the array
+  * if value is an array, the result is key=v1 key=v2... for each value in the array
     `...['cmdline_linux']['console'] = [ 'x', 'y'']` results in `console=x console=y`
 
   * otherwise we simply insert key=value

--- a/README.md
+++ b/README.md
@@ -23,6 +23,43 @@ file will remain intact.  You can tweak the settings in the
 Policefile.rb or directly using attributes. All GRUB specific settings
 should use underscores like the examples below.
 
+### Hash merging
+Values provided as hashes (under ['grub']['config']['settings'][key] will be merged/flattened to form strings.
+This is intended to allow overrides to, for example, kernel boot options without ugly string manipulation.
+
+This approach is probably best demonstrated using an example:
+
+```ruby
+default['grub']['config']['settings']['cmdline_linux']['biosdevname'] = '0'
+default['grub']['config']['settings']['cmdline_linux']['nomodeset'] = nil
+default['grub']['config']['settings']['cmdline_linux']['console'] = [ 'tty0', 'ttyS1,115200n8']
+```
+
+is the precise equivalent of
+```ruby
+default['grub']['config']['settings']['cmdline_linux'] = 'biosdevname=0 nomodeset console=tty0 console=ttyS1,115200n8'
+```
+
+Using hashes permits simple overrides like the following
+```ruby
+node.override[grub']['config']['settings']['cmdline_linux']['biosdevname'] = '1'
+```
+
+### How hash values are merged
+for each key = value pair in the hash:
+
+  * if value is `nil`, it is omitted and the key is inserted without a value
+    `...[cmdline_linux']['nomodeset'] = nil` results in `nomodeset`
+
+  * if value is an array, the result is key=v1 key=v2... once for each value in the array
+    `...['cmdline_linux']['console'] = [ 'x', 'y'']` results in `console=x console=y`
+
+  * otherwise we simply insert key=value
+    `...['cmdline_linux']['biosdevname'] = '0'` results in `biosdevname=0`
+
+
+To permit overrides to (for example) commandline options it is possible to specify
+
 ### Recipe
 ```ruby
 node.default['grub']['config']['settings']['timeout'] = 30

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -12,22 +12,22 @@ property :path, String, name_property: true
 property :settings, Hash, default: {}
 
 def merge_args(arghash)
-    out = []
-    arghash.each do |key, val|
-      # if a value is an array return key=val for each val in v
-      # allows multiple args like console= in kernel boot parameters
-      if val.is_a?(Array)
-        val.each do |v|
-          out << "#{key}=#{v}"
-        end
-      elsif val.nil?
-        # if value is null, just return the key (effectively a boolean flag)
-        out << key.to_s
-      else
-        out << "#{key}=#{val}"
+  out = []
+  arghash.each do |key, val|
+    # if a value is an array return key=val for each val in v
+    # allows multiple args like console= in kernel boot parameters
+    if val.is_a?(Array)
+      val.each do |v|
+        out << "#{key}=#{v}"
       end
+    elsif val.nil?
+      # if value is null, just return the key (effectively a boolean flag)
+      out << key.to_s
+    else
+      out << "#{key}=#{val}"
     end
-    out.join(' ')
+  end
+  out.join(' ')
 end
 
 def content
@@ -35,9 +35,7 @@ def content
     next n.flatten.map(&:to_s).join(',') if n.is_a?(Array)
     n
   end.map do |k, v|
-    if v.is_a?(Hash)
-      v = merge_args(v)
-    end
+    v = merge_args(v) if v.is_a?(Hash)
     'GRUB_' << k.upcase << ((v.is_a?(String) && v =~ /[\W\s]+/) ? "=\"#{v}\"" : "=#{v}")
   end.join("\n")
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -11,11 +11,33 @@ provides :grub_config
 property :path, String, name_property: true
 property :settings, Hash, default: {}
 
+def merge_args(arghash)
+    out = []
+    arghash.each do |key, val|
+      # if a value is an array return key=val for each val in v
+      # allows multiple args like console= in kernel boot parameters
+      if val.is_a?(Array)
+        val.each do |v|
+          out << "#{key}=#{v}"
+        end
+      elsif val.nil?
+        # if value is null, just return the key (effectively a boolean flag)
+        out << key.to_s
+      else
+        out << "#{key}=#{val}"
+      end
+    end
+    out.join(' ')
+end
+
 def content
   settings.merge({}) do |_k, _o, n|
     next n.flatten.map(&:to_s).join(',') if n.is_a?(Array)
     n
   end.map do |k, v|
+    if v.is_a?(Hash)
+      v = merge_args(v)
+    end
     'GRUB_' << k.upcase << ((v.is_a?(String) && v =~ /[\W\s]+/) ? "=\"#{v}\"" : "=#{v}")
   end.join("\n")
 end


### PR DESCRIPTION
# Add support for hashes in grub settings
allows the various option strings to be expressed as attribute hashes

This applies mostly to boot options, where in some environments/on specific hardware we need to override/append to standard kernel commandline strings. 

this PR permits us to do the following:
```
default['grub']['config']['settings']['cmdline_linux']['biosdevname'] = '0'
default['grub']['config']['settings']['cmdline_linux']['nomodeset'] = nil
default['grub']['config']['settings']['cmdline_linux']['console'] = [ 'tty0', 'ttyS1,115200n8']
```
and have them rendered as
`GRUB_CMDLINE_LINUX="biosdevname=0 nomodeset console=tty0 console=ttyS1,115200n8"`

The original string representations still work, so 
`default['grub']['config']['settings']'cmdline_linux'] = "biosdevname=0 nomodeset console=tty0 console=ttyS1,115200n8"`
would have the same effect

## but WHY?
This allows us to override/append individual boot arguments in different environments without repetition or nasty/ugly string manipulation

## How hashes are parsed
a hash under `grub.config.settings` is rendered into a string according to the 

  * options with no arguments: 
      `{ "name" => nil }`
  *  options that take values:
      `{"name" => 'value' }`
    - the values should be strings, unless you want ruby to evaluate them
  * options than can appear multiple times (with values) are arrays, rendered in order:
    `{"console" => ["tty0", "ttyS1,115200n8" ] }`